### PR TITLE
Определение типа перекрёстка

### DIFF
--- a/gym_custom/env.py
+++ b/gym_custom/env.py
@@ -1,26 +1,24 @@
-try:
-    import pyglet
-    pyglet.window.Window()
-    from pyglet.window import key
-except Exception:
-    pass
+import pyglet
+
+pyglet.window.Window()
+from pyglet.window import key
 
 import logging
 import sys
-
-try:
-    from gym_duckietown.simulator import Simulator, DEFAULT_ROBOT_SPEED, DEFAULT_CAMERA_WIDTH, DEFAULT_CAMERA_HEIGHT
-except Exception:
-    pass
-
-from wrappers.general_wrappers import InconvenientSpawnFixingWrapper
-from wrappers.observe_wrappers import ResizeWrapper, NormalizeWrapper, ClipImageWrapper, MotionBlurWrapper, SegmentationWrapper, RandomFrameRepeatingWrapper, ObservationBufferWrapper, RGB2GrayscaleWrapper, LastPictureObsWrapper
-from wrappers.reward_wrappers import DtRewardTargetOrientation, DtRewardVelocity, DtRewardCollisionAvoidance, DtRewardPosingLaneWrapper, DtRewardPosAngle
-from wrappers.action_wpappers import Heading2WheelVelsWrapper, ActionSmoothingWrapper
-from wrappers.envWrapper import ActionDelayWrapper, ForwardObstacleSpawnnigWrapper, ObstacleSpawningWrapper, TileWrapper
-from wrappers.aido_wrapper import AIDOWrapper
 import random
 import numpy as np
+
+from gym_duckietown.simulator import Simulator, DEFAULT_ROBOT_SPEED, DEFAULT_CAMERA_WIDTH, DEFAULT_CAMERA_HEIGHT
+
+from .wrappers.general_wrappers import InconvenientSpawnFixingWrapper
+from .wrappers.observe_wrappers import ResizeWrapper, NormalizeWrapper, ClipImageWrapper, MotionBlurWrapper, SegmentationWrapper, RandomFrameRepeatingWrapper, ObservationBufferWrapper, RGB2GrayscaleWrapper, LastPictureObsWrapper
+from .wrappers.reward_wrappers import DtRewardTargetOrientation, DtRewardVelocity, DtRewardCollisionAvoidance, DtRewardPosingLaneWrapper, DtRewardPosAngle
+from .wrappers.action_wpappers import Heading2WheelVelsWrapper, ActionSmoothingWrapper
+from .wrappers.envWrapper import ActionDelayWrapper, ForwardObstacleSpawnnigWrapper, ObstacleSpawningWrapper, TileWrapper
+from .wrappers.aido_wrapper import AIDOWrapper
+
+from ray.tune import register_env
+
 
 logger = logging.getLogger(__name__)
 
@@ -57,8 +55,13 @@ class Environment:
         self._env = MotionBlurWrapper(self._env)
         self._env = NormalizeWrapper(self._env)
         self._env = Heading2WheelVelsWrapper(self._env)
-        self._env = TileWrapper(self._env)
         #self._env = ActionSmoothingWrapper(self._env)
         #self._env = DtRewardTargetOrientation(self._env)
         #self._env = DtRewardVelocity(self._env)
         #self._env = DtRewardCollisionAvoidance(self._env)
+        self._env = TileWrapper(self._env)
+
+
+
+env = Environment(random.randint(0, 100000))
+register_env('Duckietown', env.create_env)

--- a/gym_custom/env.py
+++ b/gym_custom/env.py
@@ -1,24 +1,26 @@
-import pyglet
-
-pyglet.window.Window()
-from pyglet.window import key
+try:
+    import pyglet
+    pyglet.window.Window()
+    from pyglet.window import key
+except Exception:
+    pass
 
 import logging
 import sys
+
+try:
+    from gym_duckietown.simulator import Simulator, DEFAULT_ROBOT_SPEED, DEFAULT_CAMERA_WIDTH, DEFAULT_CAMERA_HEIGHT
+except Exception:
+    pass
+
+from wrappers.general_wrappers import InconvenientSpawnFixingWrapper
+from wrappers.observe_wrappers import ResizeWrapper, NormalizeWrapper, ClipImageWrapper, MotionBlurWrapper, SegmentationWrapper, RandomFrameRepeatingWrapper, ObservationBufferWrapper, RGB2GrayscaleWrapper, LastPictureObsWrapper
+from wrappers.reward_wrappers import DtRewardTargetOrientation, DtRewardVelocity, DtRewardCollisionAvoidance, DtRewardPosingLaneWrapper, DtRewardPosAngle
+from wrappers.action_wpappers import Heading2WheelVelsWrapper, ActionSmoothingWrapper
+from wrappers.envWrapper import ActionDelayWrapper, ForwardObstacleSpawnnigWrapper, ObstacleSpawningWrapper, TileWrapper
+from wrappers.aido_wrapper import AIDOWrapper
 import random
 import numpy as np
-
-from gym_duckietown.simulator import Simulator, DEFAULT_ROBOT_SPEED, DEFAULT_CAMERA_WIDTH, DEFAULT_CAMERA_HEIGHT
-
-from .wrappers.general_wrappers import InconvenientSpawnFixingWrapper
-from .wrappers.observe_wrappers import ResizeWrapper, NormalizeWrapper, ClipImageWrapper, MotionBlurWrapper, SegmentationWrapper, RandomFrameRepeatingWrapper, ObservationBufferWrapper, RGB2GrayscaleWrapper, LastPictureObsWrapper
-from .wrappers.reward_wrappers import DtRewardTargetOrientation, DtRewardVelocity, DtRewardCollisionAvoidance, DtRewardPosingLaneWrapper, DtRewardPosAngle
-from .wrappers.action_wpappers import Heading2WheelVelsWrapper, ActionSmoothingWrapper
-from .wrappers.envWrapper import ActionDelayWrapper, ForwardObstacleSpawnnigWrapper, ObstacleSpawningWrapper
-from .wrappers.aido_wrapper import AIDOWrapper
-
-from ray.tune import register_env
-
 
 logger = logging.getLogger(__name__)
 
@@ -55,12 +57,8 @@ class Environment:
         self._env = MotionBlurWrapper(self._env)
         self._env = NormalizeWrapper(self._env)
         self._env = Heading2WheelVelsWrapper(self._env)
+        self._env = TileWrapper(self._env)
         #self._env = ActionSmoothingWrapper(self._env)
         #self._env = DtRewardTargetOrientation(self._env)
         #self._env = DtRewardVelocity(self._env)
         #self._env = DtRewardCollisionAvoidance(self._env)
-
-
-
-env = Environment(random.randint(0, 100000))
-register_env('Duckietown', env.create_env)

--- a/gym_custom/wrappers/envWrapper.py
+++ b/gym_custom/wrappers/envWrapper.py
@@ -402,43 +402,43 @@ class TileWrapper(gym.Wrapper):
         return self.env.unwrapped._get_tile(tile_coords[0], tile_coords[1])
         
     def next_tile(self, tc, pos, phi):
-	    cons_next = []	# Рассматриваемые тайлы
-	    crossroads = ['3way_left', '4way']
-	    
-	    dx = sign(cos(phi))
-	    dy = -sign(sin(phi))
-	    atphi = abs(tan(phi))
-	    
-	    tcx = tc[0] + dx
-	    tcy = tc[1] + dy
-	    
-	    if sin(phi) == 0 or cos(phi) == 0: # Если взгляд перпендикулярен тайлу
-	        cons_next.append( [tc[0] + dx, tc[1] + dy] )
-	    else:	# Сравнение углов, чтобы выбрать нужный тайл
-	    # Соотношение сторон прямоугольника, в который попадает луч взгляда
-	        tga = ( (2*int(cos(phi) < 0) - 1)*(tc[1] + int(phi < 0)) + (2*int(cos(phi) > 0) - 1)*pos[2] )\
-	        / ( (2*int(cos(phi) > 0) - 1)*(tc[0] + int(cos(phi) > 0)) + (2*int(cos(phi) < 0) - 1)*pos[0] )
-	        
-	        if atphi < abs(tga):
-	            cons_next.append( [tcx, tc[1]] )
-	        elif atphi > abs(tga):
-	            cons_next.append( [tc[0], tcy] )
-	        else:
-	            if atphi <= 1:
-	                cons_next.append( [tcx, tc[1]] )
-	            if atphi >= 1:
-	                cons_next.append( [tc[0], tcy] )
-	    # Проверка тайлов на принадлежность перекрёсткам и выбор из двух тайлов (в случае неопределённости направления взгляда)
-	    tile1 = self.gettile(cons_next[0])
-	    if len(cons_next) == 1 and tile1 and tile1['kind'] in crossroads:
-	        return self.gettile(cons_next[0])['kind']
-	    if len(cons_next) > 1:
-	        tile2 = self.gettile(cons_next[1])
-	        if tile1 and tile1['kind'] in crossroads and tile2 and tile2['kind'] in crossroads:
-	            return self.gettile(cons_next[ri(0,1)])['kind']
-	        if tile1 and tile1['kind'] in crossroads:
-	            return tile1['kind']
-	        if tile2 and tile2['kind'] in crossroads:
-	            return tile2['kind']
-	        return None
-	    return None
+        cons_next = []	# Рассматриваемые тайлы
+        crossroads = ['3way_left', '4way']
+        
+        dx = sign(cos(phi))
+        dy = -sign(sin(phi))
+        atphi = abs(tan(phi))
+        
+        tcx = tc[0] + dx
+        tcy = tc[1] + dy
+        
+        if sin(phi) == 0 or cos(phi) == 0: # Если взгляд перпендикулярен тайлу
+            cons_next.append( [tc[0] + dx, tc[1] + dy] )
+        else:	# Сравнение углов, чтобы выбрать нужный тайл
+            # Соотношение сторон прямоугольника, в который попадает луч взгляда
+            tga = ( (2*int(cos(phi) < 0) - 1)*(tc[1] + int(phi < 0)) + (2*int(cos(phi) > 0) - 1)*pos[2] )\
+            / ( (2*int(cos(phi) > 0) - 1)*(tc[0] + int(cos(phi) > 0)) + (2*int(cos(phi) < 0) - 1)*pos[0] )
+            
+            if atphi < abs(tga):
+                cons_next.append( [tcx, tc[1]] )
+            elif atphi > abs(tga):
+                cons_next.append( [tc[0], tcy] )
+            else:
+                if atphi <= 1:
+                    cons_next.append( [tcx, tc[1]] )
+                if atphi >= 1:
+                    cons_next.append( [tc[0], tcy] )
+        # Проверка тайлов на принадлежность перекрёсткам и выбор из двух тайлов (в случае неопределённости направления взгляда)
+        tile1 = self.gettile(cons_next[0])
+        if len(cons_next) == 1 and tile1 and tile1['kind'] in crossroads:
+            return self.gettile(cons_next[0])['kind']
+        if len(cons_next) > 1:
+            tile2 = self.gettile(cons_next[1])
+            if tile1 and tile1['kind'] in crossroads and tile2 and tile2['kind'] in crossroads:
+                return self.gettile(cons_next[ri(0,1)])['kind']
+            if tile1 and tile1['kind'] in crossroads:
+                return tile1['kind']
+            if tile2 and tile2['kind'] in crossroads:
+                return tile2['kind']
+            return None
+        return None

--- a/tools/run.py
+++ b/tools/run.py
@@ -42,9 +42,8 @@ if __name__ == "__main__":
             print(f"{c}. {action}")
             c += 1
             obs, reward, done, info = env.step(action)
-            ntl = env.next_tile(info["Simulator"]["tile_coords"], info["Simulator"]["cur_pos"], info["Simulator"]["cur_angle"])
-            if ntl:
-                print(c, ntl)
+            if info["Simulator"]["next_crossroad"]:
+                print(c, info["Simulator"]["next_crossroad"])
             env.render()
 
 

--- a/tools/run.py
+++ b/tools/run.py
@@ -1,18 +1,21 @@
 import sys
+import os.path as osp
 import ray
 import argparse
-from ray import tune
 import random
+
+from ray import tune
 from ray.tune import register_env
 from ray.rllib.agents.ppo import PPOTrainer
-from utils.api import update_conf, get_default_rllib_conf, add_env_conf
-from utils.config import Config
-from env import Environment
-    
+
+sys.path.append(osp.abspath('.'))
+from gym_custom.utils.api import update_conf, get_default_rllib_conf, add_env_conf
+from gym_custom.utils.config import Config
+from gym_custom.env import Environment
 
 if __name__ == "__main__":
     parser = argparse.ArgumentParser(description="Parameters to ray trainer")
-    parser.add_argument('--conf_path', type=str, default='./configs/run_conf.py')
+    parser.add_argument('--conf_path', type=str, default='../configs/run_conf.py')
     args = parser.parse_args()
 
     config = Config.fromfile(args.conf_path)
@@ -36,12 +39,13 @@ if __name__ == "__main__":
         c = 0
         while not done:
             action = trainer.compute_action(obs, explore=False)
-            #print(f"{c}. {action}")
+            print(f"{c}. {action}")
             c += 1
             obs, reward, done, info = env.step(action)
             ntl = env.next_tile(info["Simulator"]["tile_coords"], info["Simulator"]["cur_pos"], info["Simulator"]["cur_angle"])
             if ntl:
                 print(c, ntl)
             env.render()
+
 
 

--- a/tools/run.py
+++ b/tools/run.py
@@ -1,21 +1,18 @@
 import sys
-import os.path as osp
 import ray
 import argparse
-import random
-
 from ray import tune
+import random
 from ray.tune import register_env
 from ray.rllib.agents.ppo import PPOTrainer
-
-sys.path.append(osp.abspath('.'))
-from gym_custom.utils.api import update_conf, get_default_rllib_conf, add_env_conf
-from gym_custom.utils.config import Config
-from gym_custom.env import Environment
+from utils.api import update_conf, get_default_rllib_conf, add_env_conf
+from utils.config import Config
+from env import Environment
+    
 
 if __name__ == "__main__":
     parser = argparse.ArgumentParser(description="Parameters to ray trainer")
-    parser.add_argument('--conf_path', type=str, default='../configs/run_conf.py')
+    parser.add_argument('--conf_path', type=str, default='./configs/run_conf.py')
     args = parser.parse_args()
 
     config = Config.fromfile(args.conf_path)
@@ -39,10 +36,12 @@ if __name__ == "__main__":
         c = 0
         while not done:
             action = trainer.compute_action(obs, explore=False)
-            print(f"{c}. {action}")
+            #print(f"{c}. {action}")
             c += 1
             obs, reward, done, info = env.step(action)
+            ntl = env.next_tile(info["Simulator"]["tile_coords"], info["Simulator"]["cur_pos"], info["Simulator"]["cur_angle"])
+            if ntl:
+                print(c, ntl)
             env.render()
-
 
 

--- a/tools/run.py
+++ b/tools/run.py
@@ -42,7 +42,7 @@ if __name__ == "__main__":
             print(f"{c}. {action}")
             c += 1
             obs, reward, done, info = env.step(action)
-            if info["Simulator"]["next_crossroad"]:
+            if "next_crossroad" in info["Simulator"].keys() and info["Simulator"]["next_crossroad"]:
                 print(c, info["Simulator"]["next_crossroad"])
             env.render()
 


### PR DESCRIPTION
Написана обёртка TileWrapper, позволяющая получать доступ к клеткам поля и определять тип клетки, которая находится перед агентом. На данный момент распознаются перекрёстки двух типов: 3way_left и 4way. При необходимости возможно изменение множества распознаваемых клеток.