### PR TITLE
Состояние при нахождении на перекрёстке

### DIFF
--- a/gym_custom/wrappers/envWrapper.py
+++ b/gym_custom/wrappers/envWrapper.py
@@ -397,11 +397,30 @@ class ForwardObstacleSpawnnigWrapper(gym.Wrapper):
 class TileWrapper(gym.Wrapper):
     def __init__(self, env):
        super(TileWrapper, self).__init__(env)
+       
+       self._tile = None
+       self._state = None
+       
+       self._cr_dirs = [[0, 1], [1, 0], [0, -1], [-1, 0]]
+       
+       self._dirs = {
+           "laneFollowing": 0,
+           "left": 1,
+           "forward": 2,
+           "right": 3
+           }
+       
+       self._moves = {
+           "curve_left": ["laneFollowing"],
+           "straight": ["laneFollowing"],
+           "4way": ["left", "forward", "right"],
+           "3way_left": [ ["forward", "right"], ["left", "right"], ["left", "forward"] ]
+           }
     
-    def gettile(self, tile_coords:list):
+    def _gettile(self, tile_coords:list):
         return self.env.unwrapped._get_tile(tile_coords[0], tile_coords[1])
         
-    def next_tile(self, tc:list, pos:list, phi:float):
+    def _next_crossroad(self, tc:list, pos:list, phi:float):
         cons_next = []	# Рассматриваемые тайлы
         crossroads = ['3way_left', '4way']
         
@@ -429,13 +448,13 @@ class TileWrapper(gym.Wrapper):
                 if atphi >= 1:
                     cons_next.append( [tc[0], tcy] )
         # Проверка тайлов на принадлежность перекрёсткам и выбор из двух тайлов (в случае неопределённости направления взгляда)
-        tile1 = self.gettile(cons_next[0])
+        tile1 = self._gettile(cons_next[0])
         if len(cons_next) == 1 and tile1 and tile1['kind'] in crossroads:
-            return self.gettile(cons_next[0])['kind']
+            return self._gettile(cons_next[0])['kind']
         if len(cons_next) > 1:
-            tile2 = self.gettile(cons_next[1])
+            tile2 = self._gettile(cons_next[1])
             if tile1 and tile1['kind'] in crossroads and tile2 and tile2['kind'] in crossroads:
-                return self.gettile(cons_next[ri(0,1)])['kind']
+                return self._gettile(cons_next[ri(0,1)])['kind']
             if tile1 and tile1['kind'] in crossroads:
                 return tile1['kind']
             if tile2 and tile2['kind'] in crossroads:
@@ -443,8 +462,31 @@ class TileWrapper(gym.Wrapper):
             return None
         return None
     
+    def _directions(self, ppos: list, npos: list, nkind: str, cr_dir: int) -> list:
+        if nkind != "3way_left":
+            if nkind in self._moves.keys():
+                return [ self._dirs[i] for i in self._moves[nkind] ]
+            return []
+        
+        v_bot = [ npos[0] - ppos[0], npos[1] - ppos[1] ]
+        v_cr = self._cr_dirs[cr_dir]
+        index = int(np.dot(v_bot, v_cr)) + 1
+        return [ self._dirs[i] for i in self._moves[nkind][index] ]
+    
     def step(self, action: np.ndarray) -> tuple:
         obs, reward, done, info = super(TileWrapper, self).step(action)
-        info["Simulator"]["next_crossroad"] = self.next_tile(info["Simulator"]["tile_coords"], info["Simulator"]["cur_pos"], info["Simulator"]["cur_angle"])
+        
+        info["Simulator"]["next_crossroad"] = self._next_crossroad(info["Simulator"]["tile_coords"], info["Simulator"]["cur_pos"], info["Simulator"]["cur_angle"])
+        
+        cur_tile = self._gettile(info["Simulator"]["tile_coords"])
+        if not self._tile:
+            self._state = 0
+            self._tile = cur_tile
+        elif self._tile is not cur_tile:
+            directions = self._directions(self._tile["coords"], cur_tile["coords"], cur_tile["kind"], cur_tile["angle"])
+            self._state = directions[ri(0, len(directions) - 1)]
+            self._tile = cur_tile
+        
+        info["direction"] = self._state
         return obs, reward, done, info
         

--- a/gym_custom/wrappers/envWrapper.py
+++ b/gym_custom/wrappers/envWrapper.py
@@ -401,7 +401,13 @@ class TileWrapper(gym.Wrapper):
        self._tile = None
        self._state = None
        
-       self._cr_dirs = [[0, 1], [1, 0], [0, -1], [-1, 0]]
+       self._cr_dirs = ["south", "east", "north", "west"]
+       self._cr_vectors = {
+           "south": [0, 1],
+           "east": [1, 0],
+           "north": [0, -1],
+           "west": [-1, 0]
+           }
        
        self._dirs = {
            "laneFollowing": 0,
@@ -462,7 +468,6 @@ class TileWrapper(gym.Wrapper):
             return None
         return None
     
-
     def _directions(self, ppos: list, npos: list, nkind: str, cr_dir: int) -> list:
         if nkind != "3way_left":
             if nkind in self._moves.keys():
@@ -470,7 +475,7 @@ class TileWrapper(gym.Wrapper):
             return []
         
         v_bot = [ npos[0] - ppos[0], npos[1] - ppos[1] ]
-        v_cr = self._cr_dirs[cr_dir]
+        v_cr = self._cr_vectors[self._cr_dirs[cr_dir]]
         index = int(np.dot(v_bot, v_cr)) + 1
         return [ self._dirs[i] for i in self._moves[nkind][index] ]
     


### PR DESCRIPTION
В метод step класса TileWrapper добавлен случайный выбор одного из допустимых направлений поворота (или просто движения, если бот не находится на перекрёстке). Поле класса state содержит целое значение, обозначающее выбранное направление движения в текущей клетке.
Переименован метод next_tile, так как не вполне корректно отражал суть выполняемых методом действий.